### PR TITLE
Fix typo on app directory

### DIFF
--- a/preload.php
+++ b/preload.php
@@ -53,8 +53,8 @@ preload(
         __DIR__ . '/vendor/composer/autoload_namespaces.php',
         __DIR__ . '/vendor/composer/autoload_files.php',
         __DIR__ . '/vendor/composer/autoload_classmap.php',
-        __DIR__ . '/epp/etc/config.php',
-        __DIR__ . '/epp/etc/env.php',
+        __DIR__ . '/app/etc/config.php',
+        __DIR__ . '/app/etc/env.php',
         __DIR__ . '/vendor/autoload.php',
     ],
     []


### PR DESCRIPTION
Spotted that app/etc/config.php and app/etc/env.php wouldn't be loaded up